### PR TITLE
Allow file-less attachments

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -16,13 +16,15 @@ const getSafeFilename = sri4nodeAttachments.__get__('getSafeFilename');
  *  urlToCopy?: string,
  *  localFilename: string,
  *  attachmentKey: string,
- *  resourceHref: string
+ *  resourceHref: string,
+ *  attachment?: {description?: string; href?: string;}
  * } } TFileToUpload
  * @typedef { {
  *  remotefileName?: string,
  *  urlToCopy?: string,
  *  attachmentKey: string,
- *  resourceHref: string
+ *  resourceHref: string,
+ *  attachment?: {description?: string; href?: string;}
  * } } TFileToCopy
  * 
  * @typedef { import("./httpClient.js").THttpClient } THttpClient
@@ -83,14 +85,21 @@ const deleteAttachmentAndVerify = async (
  */
 const createUploadBody = (fileDetails) => {
   return fileDetails.map(
-    ({ remotefileName, attachmentKey, resourceHref, urlToCopy }) => ({
+    ({
+      remotefileName,
+      attachmentKey,
+      resourceHref,
+      urlToCopy,
+      attachment,
+    }) => ({
       file: remotefileName, // can be undefined in that case of copy (in this case the name of the original file is taken)
-      fileHref: urlToCopy,  // can be undefined, but if it's there, this is the url that should be copied
-                            // instead of uploading a local file
+      fileHref: urlToCopy, // can be undefined, but if it's there, this is the url that should be copied
+      // instead of uploading a local file
       attachment: {
         key: attachmentKey,
         description: `this is MY file with key ${attachmentKey}`,
         aCustomTestProperty: 1000,
+        ...attachment,
       },
       resource: {
         href: resourceHref,

--- a/test/context/config.js
+++ b/test/context/config.js
@@ -33,12 +33,12 @@ module.exports = async function (handleMultipleUploadsTogether = false, uploadIn
     description: "",
     logdebug: {
       channels: [
-        "sri4node-attachments",
-        "trace",
-        "general",
-        "batch",
-        "db",
-        "sql",
+        // "sri4node-attachments",
+        // "trace",
+        // "general",
+        // "batch",
+        // "db",
+        // "sql",
       ],
     },
     resources: [

--- a/test/context/parties.js
+++ b/test/context/parties.js
@@ -39,6 +39,7 @@ module.exports = function (sri4node, attachments, type, customStoreAttachment, c
   function attachmentJson(attFile, resourceKey, attachmentKey) {
     const nowString = new Date().toISOString();
     return {
+      ...attFile.attachment,
       $$meta: {
         created: nowString,
         modified: nowString,
@@ -47,8 +48,7 @@ module.exports = function (sri4node, attachments, type, customStoreAttachment, c
       href: `${type}/${resourceKey}/attachments/${attachmentKey}`,
       key: attFile.attachment.key,
       name: attFile.file,
-      description: attFile.attachment.description,
-      contentType: attFile.fileObj.mimeType,
+      contentType: attFile.fileObj?.mimeType,
     };
   }
 

--- a/test/context/parties.js
+++ b/test/context/parties.js
@@ -182,7 +182,7 @@ module.exports = function (sri4node, attachments, type, customStoreAttachment, c
       attachments.customRouteForDownload(customCheckDownload),
       attachments.customRouteForDelete(
         async (_tx, _sriRequest, resourceKey, attachmentKey) =>
-          resourceMap[resourceKey][attachmentKey].fileObj.filename,
+          resourceMap[resourceKey][attachmentKey]?.fileObj?.filename,
         async (_tx, _sriRequest, resourceKey, attachmentKey) => {
           delete resourceMap[resourceKey][attachmentKey];
         }

--- a/test/testPartyAttachments.js
+++ b/test/testPartyAttachments.js
@@ -924,7 +924,7 @@ exports = module.exports = function (httpClient, type) {
 
     });
 
-    describe.only("file-less attachment", function () {
+    describe("file-less attachment", function () {
       let putAttachmentsResponse;
       let partyPutResponse;
       let attachment;

--- a/test/testPartyAttachmentsCheckStoreAttachment.js
+++ b/test/testPartyAttachmentsCheckStoreAttachment.js
@@ -20,7 +20,7 @@ const { uploadFilesAndCheck, copyFilesAndCheck } = require("./common.js");
  * @param {*} file 
  */
 const checkStoreAttachment = (file) => {
-  if (file.file === null || typeof file.file !== 'object') {
+  if (file.file && typeof file.file !== 'object') {
     throw new SriError({
       status: 500,
       errors: [
@@ -41,7 +41,7 @@ const checkStoreAttachment = (file) => {
     'hash',
   ];
   expectedFileProperties.forEach(prop => {
-    if (file.file[prop] === undefined) {
+    if (file.file && file.file[prop] === undefined) {
       throw new SriError({
         status: 500,
         errors: [
@@ -146,7 +146,9 @@ function checkStoreAttachmentFactory(handleMultipleUploadsTogether, uploadInSequ
       throw new Error("checkStoreAttachmentsReceivedList must be an array, if uploadInSequence is true");
     }
     return (file) => {
-      checkStoreAttachmentsReceivedList.push(file.fileObj.filename.substring(0,8));
+      if (file.fileObj) {
+        checkStoreAttachmentsReceivedList.push(file.fileObj.filename.substring(0,8));
+      }
       checkStoreAttachment(file);
     };
   }

--- a/test/testPartyAttachmentsCheckStoreAttachment.js
+++ b/test/testPartyAttachmentsCheckStoreAttachment.js
@@ -5,7 +5,20 @@ const { SriError } = require("sri4node");
 
 const { uploadFilesAndCheck, copyFilesAndCheck } = require("./common.js");
 
-
+/**
+ * This JavaScript function, checkStoreAttachment, validates the structure and properties of the
+ * file object.
+ * It checks if the file object has three properties: file, attachment, and resource.
+ * Each of these properties should be an object and have certain expected properties.
+ *  * file.file should be an object and have the properties: mimetype, filename, tmpFileName, size, and hash.
+ *  * file.attachment should be an object and have the properties: key, description, and aCustomTestProperty.
+ *  * file.resource should be an object and have the properties: href and key.
+ * If any of these conditions are not met, the function throws an error (SriError) with a status
+ * of 500 and a detailed error message. The error message includes the specific property that is
+ * missing or the specific object that is not an object.
+ *
+ * @param {*} file 
+ */
 const checkStoreAttachment = (file) => {
   if (file.file === null || typeof file.file !== 'object') {
     throw new SriError({
@@ -108,17 +121,30 @@ const checkStoreAttachment = (file) => {
 
 
 /**
- * 
- * @param {*} handleMultipleUploadsTogether 
- * @param {*} uploadInSequence 
- * @param {*} checkStoreAttachmentsReceivedList 
- * @returns 
+ * This factory will create a handler function that can be passed to sri4node attachments
+ * runAfterUpload handler.
+ *
+ * You can decide with the flags whether you want to handle multiple uploads together or
+ * upload in sequence. In case of multiple uploads together, the handler function will
+ * receive an array of files. In case of upload in sequence, the handler function will
+ * receive a single file.
+ * If handleMultipleUploadsTogether=false and uploadInSequence=true, a thrird parameter
+ * is required, which is a reference to an array that is used to store the attachments.
+ * This can be used somewhere else inu the tests to verify the order of the uploads.
+ *
+ * @param {boolean} handleMultipleUploadsTogether 
+ * @param {boolean} uploadInSequence 
+ * @param {Array<string>} checkStoreAttachmentsReceivedList a reference to an array that is used to store the attachments, which will be used to verify the order of the uploads (in a few cases)
+ * @returns
  */
-function checkStoreAttachmentsFactory(handleMultipleUploadsTogether, uploadInSequence, checkStoreAttachmentsReceivedList = undefined) {
+function checkStoreAttachmentFactory(handleMultipleUploadsTogether, uploadInSequence, checkStoreAttachmentsReceivedList = undefined) {
   if (handleMultipleUploadsTogether) {
     return (files) => files.forEach(file => checkStoreAttachment(file));
   }
   if (uploadInSequence) {
+    if (!Array.isArray(checkStoreAttachmentsReceivedList)) {
+      throw new Error("checkStoreAttachmentsReceivedList must be an array, if uploadInSequence is true");
+    }
     return (file) => {
       checkStoreAttachmentsReceivedList.push(file.fileObj.filename.substring(0,8));
       checkStoreAttachment(file);
@@ -138,13 +164,22 @@ function verifyCheckStoreAttachmentsReceivedListOrder(checkStoreAttachmentsRecei
     const checkStoreAttachmentsReceivedListCopy = [...checkStoreAttachmentsReceivedList];
     checkStoreAttachmentsReceivedListCopy.sort();
     assert.deepStrictEqual(checkStoreAttachmentsReceivedList, checkStoreAttachmentsReceivedListCopy);
+  } else {
+    assert.fail("[verifyCheckStoreAttachmentsReceivedListOrder] checkStoreAttachmentsReceivedList is empty, which is unexpected. Checking the order of uploads is only useful when handleMultipleUploadsTogether = false and upladoInSequence = true (cfr. checkStoreAttachmentFactory).");
   }
 }
 
 
 exports = module.exports = {
-  checkStoreAttachmentFactory: checkStoreAttachmentsFactory,
-  factory: function (httpClient, type, checkStoreAttachmentsReceivedList) {
+  checkStoreAttachmentFactory,
+  /**
+   * 
+   * @param {*} httpClient 
+   * @param {*} type 
+   * @param {*} checkStoreAttachmentsReceivedList a reference to the same array that is also passed in the checkStoreAttachmentFactory as a parameter, which will be used to verify the order of the uploads (in a few cases)
+   */
+  factory: function (httpClient, type, checkStoreAttachmentsReceivedList = null) {
+    // const checkStoreAttachmentsReceivedList = [];
     describe(type, function () {
       describe("checkStoreAttachment", function () {
         it("UPLOAD and COPY via upload", async () => {
@@ -193,9 +228,9 @@ exports = module.exports = {
               },
             ];
 
-            clearCheckStoreAttachmentsReceivedList(checkStoreAttachmentsReceivedList);
+            if (checkStoreAttachmentsReceivedList) clearCheckStoreAttachmentsReceivedList(checkStoreAttachmentsReceivedList);
             await uploadFilesAndCheck(httpClient, filesToPut);
-            verifyCheckStoreAttachmentsReceivedListOrder(checkStoreAttachmentsReceivedList);
+            if (checkStoreAttachmentsReceivedList) verifyCheckStoreAttachmentsReceivedListOrder(checkStoreAttachmentsReceivedList);
 
             // Multiple upload with attachments copies with new names
             const filesToPut2 = [
@@ -225,9 +260,9 @@ exports = module.exports = {
               },
             ];
 
-            clearCheckStoreAttachmentsReceivedList(checkStoreAttachmentsReceivedList);
+            if (checkStoreAttachmentsReceivedList) clearCheckStoreAttachmentsReceivedList(checkStoreAttachmentsReceivedList);
             await uploadFilesAndCheck(httpClient, filesToPut2);
-            verifyCheckStoreAttachmentsReceivedListOrder(checkStoreAttachmentsReceivedList);
+            if (checkStoreAttachmentsReceivedList) verifyCheckStoreAttachmentsReceivedListOrder(checkStoreAttachmentsReceivedList);
 
           } catch (err) {
             assert.fail([err.err]);
@@ -280,7 +315,9 @@ exports = module.exports = {
               },
             ];
 
+            if (checkStoreAttachmentsReceivedList) clearCheckStoreAttachmentsReceivedList(checkStoreAttachmentsReceivedList);
             await uploadFilesAndCheck(httpClient, filesToPut);
+            if (checkStoreAttachmentsReceivedList) verifyCheckStoreAttachmentsReceivedListOrder(checkStoreAttachmentsReceivedList);
 
             // Multiple upload with one extra attachment which is a copy of an existing attachment
             const filesToPut2 = [
@@ -310,9 +347,9 @@ exports = module.exports = {
               },
             ];
             
-            clearCheckStoreAttachmentsReceivedList(checkStoreAttachmentsReceivedList);
+            if (checkStoreAttachmentsReceivedList) clearCheckStoreAttachmentsReceivedList(checkStoreAttachmentsReceivedList);
             await copyFilesAndCheck(httpClient, filesToPut2);
-            verifyCheckStoreAttachmentsReceivedListOrder(checkStoreAttachmentsReceivedList);
+            if (checkStoreAttachmentsReceivedList) verifyCheckStoreAttachmentsReceivedListOrder(checkStoreAttachmentsReceivedList);
           } catch (err) {
             console.log(err);
             assert.fail([err.err]);

--- a/test/tests.js
+++ b/test/tests.js
@@ -92,8 +92,30 @@ describe("Unit tests : ", () => {
 //   sri4node-attachments(2) :                  true                        true
 //   sri4node-attachments(3) :                  true                        false
 
-
+// Configuration with handleMultipleUploadsTogether=false and uploadInSequence=false
 describe("sri4node-attachments(1) : ", () => {
+  /** @type {import("sri4node").TSriServerInstance} */
+  let sri4nodeServerInstance;
+  let server;
+
+  before(async () => {
+    const handleMultipleUploadsTogether = false;
+    const uploadInSequence = false;
+    const customStoreAttachment = testPartyAttachmentsCheckStoreAttachmentMod.checkStoreAttachmentFactory(handleMultipleUploadsTogether, uploadInSequence);
+    ({ sri4nodeServerInstance, server } = await initServer('1', handleMultipleUploadsTogether, uploadInSequence, customStoreAttachment));
+  });
+
+  after(async () => {
+    // enable this to keep the server running for inspection
+    // await new Promise(() => {});
+    await closeServer(server, sri4nodeServerInstance);
+  });
+
+  runTests(httpClient);
+});
+
+// Configuration with handleMultipleUploadsTogether=false and uploadInSequence=true
+describe("sri4node-attachments(2) : ", () => {
   /** @type {import("sri4node").TSriServerInstance} */
   let sri4nodeServerInstance;
   let server;
@@ -101,10 +123,9 @@ describe("sri4node-attachments(1) : ", () => {
 
   before(async () => {
     const handleMultipleUploadsTogether = false;
-    const uploadInSequence = false; // uploadInSequence value does not matter in case of handleMultipleUploadsTogether=false
-                                    // (not relevant and thus not used in that code path)
+    const uploadInSequence = true;
     const customStoreAttachment = testPartyAttachmentsCheckStoreAttachmentMod.checkStoreAttachmentFactory(handleMultipleUploadsTogether, uploadInSequence, checkStoreAttachmentsReceivedList);
-    ({ sri4nodeServerInstance, server } = await initServer('1', handleMultipleUploadsTogether, uploadInSequence, customStoreAttachment));
+    ({ sri4nodeServerInstance, server } = await initServer('2', handleMultipleUploadsTogether, uploadInSequence, customStoreAttachment));
   });
 
   after(async () => {
@@ -117,29 +138,7 @@ describe("sri4node-attachments(1) : ", () => {
 });
 
 
-// Configuration with multiple uploads together
-describe("sri4node-attachments(2) : ", () => {
-  /** @type {import("sri4node").TSriServerInstance} */
-  let sri4nodeServerInstance;
-  let server;
-
-  before(async () => {
-    const handleMultipleUploadsTogether = true;
-    const uploadInSequence = true;
-    const customStoreAttachment = testPartyAttachmentsCheckStoreAttachmentMod.checkStoreAttachmentFactory(handleMultipleUploadsTogether, uploadInSequence);
-    ({ sri4nodeServerInstance, server } = await initServer('2', handleMultipleUploadsTogether, uploadInSequence, customStoreAttachment));
-  });
-
-  after(async () => {
-    // enable this to keep the server running for inspection
-    // await new Promise(() => {});
-    await closeServer(server, sri4nodeServerInstance);
-  });
-
-  runTests(httpClient);
-});
-
-// Configuration with multiple uploads together
+// Configuration with multiple uploads together (upload in sequence does noty matter in this case)
 describe("sri4node-attachments(3) : ", () => {
   /** @type {import("sri4node").TSriServerInstance} */
   let sri4nodeServerInstance;
@@ -147,7 +146,8 @@ describe("sri4node-attachments(3) : ", () => {
 
   before(async () => {
     const handleMultipleUploadsTogether = true;
-    const uploadInSequence = false;
+    const uploadInSequence = false; // uploadInSequence value does not matter in case of handleMultipleUploadsTogether=false
+                                    // (not relevant and thus not used in that code path)
     const customStoreAttachment = testPartyAttachmentsCheckStoreAttachmentMod.checkStoreAttachmentFactory(handleMultipleUploadsTogether, uploadInSequence);
     ({ sri4nodeServerInstance, server } = await initServer('3', handleMultipleUploadsTogether, uploadInSequence, customStoreAttachment));
   });
@@ -160,6 +160,7 @@ describe("sri4node-attachments(3) : ", () => {
 
   runTests(httpClient);
 });
+
 
 describe("sri4node-attachments custom checkParentDeleted(4) : ", () => {
   /** @type {import("sri4node").TSriServerInstance} */


### PR DESCRIPTION
in the activityplans-api you can upload file-less attachments. 
they could contain only text.
this is also useful for content-api where paragraphs are seen as attachments, even though they only have text.
this was no longer supported with the changes, as it turned out.
i wanted to add a test for this, but it seems i have to turn the whole test-suite upside down to make that happen, so i did not commit those.