### PR TITLE
making createAWSS3Client also work without accessKey

### DIFF
--- a/js/sri4node-attachments.js
+++ b/js/sri4node-attachments.js
@@ -195,17 +195,27 @@ async function sri4nodeAttachmentUtilsFactory(pluginConfig, sri4node) {
    */
   function getAWSS3Client() {
     if (!this.awss3client) {
-      this.awss3client = new S3.S3Client({
-        endpoint: fullPluginConfig.endpoint, // essential to point to our localstack-on-docker
-        apiVersion: "2006-03-01",
-        region: fullPluginConfig.s3region,
-        maxAttempts: fullPluginConfig.maxRetries,
-        credentials: {
-          accessKeyId: fullPluginConfig.s3key,
-          secretAccessKey: fullPluginConfig.s3secret,
-        },
-        forcePathStyle: true, // IMPORTANT cfr. https://qubyte.codes/blog/tip-connecting-to-localstack-s3-using-the-javascript-aws-sdk-v3
-      });
+      if (fullPluginConfig.s3key && fullPluginConfig.s3secret) {
+        this.awss3client = new S3.S3Client({
+          endpoint: fullPluginConfig.endpoint, // essential to point to our localstack-on-docker
+          apiVersion: "2006-03-01",
+          region: fullPluginConfig.s3region,
+          maxAttempts: fullPluginConfig.maxRetries,
+          credentials: {
+            accessKeyId: fullPluginConfig.s3key,
+            secretAccessKey: fullPluginConfig.s3secret,
+          },
+          forcePathStyle: true, // IMPORTANT cfr. https://qubyte.codes/blog/tip-connecting-to-localstack-s3-using-the-javascript-aws-sdk-v3
+        });
+      } else {
+        this.awss3client = new S3.S3Client({
+          endpoint: fullPluginConfig.endpoint, // essential to point to our localstack-on-docker
+          apiVersion: "2006-03-01",
+          region: fullPluginConfig.s3region,
+          maxAttempts: fullPluginConfig.maxRetries,
+          forcePathStyle: true, // IMPORTANT cfr. https://qubyte.codes/blog/tip-connecting-to-localstack-s3-using-the-javascript-aws-sdk-v3
+        });
+      }
     }
     return this.awss3client;
   }


### PR DESCRIPTION
on terraform env we don't use access keys to access the attachment bucket (content-api)